### PR TITLE
Fix 84

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -68,6 +68,8 @@ export interface IBlockParameters {
     distanceMultiplier?: number;
     darkMode?: string;
     bounds?: [[number, number], [number, number]];
+    coordinates?: [string, string] | [[string]];
+    zoomTag?: string;
 }
 export interface ILeafletOverlay {
     leafletInstance: L.Circle;

--- a/src/@types/main.d.ts
+++ b/src/@types/main.d.ts
@@ -1,7 +1,4 @@
-import {
-    MarkdownPostProcessorContext,
-    Plugin,
-} from "obsidian";
+import { MarkdownPostProcessorContext, Plugin } from "obsidian";
 import { IMapInterface, IMarker, IMarkerIcon, IObsidianAppData } from ".";
 import { LeafletMap, Marker } from "./map";
 
@@ -18,14 +15,6 @@ declare class ObsidianLeaflet extends Plugin {
         el: HTMLElement,
         ctx: MarkdownPostProcessorContext
     ): Promise<void>;
-
-    /* getImmutableMarkers(
-        markers: string[],
-        commandMarkers: string[],
-        markerTags: string[][],
-        markerFiles: string[],
-        markerFolders: string[]
-    ): Promise<[string, number, number, string, string, boolean][]>; */
 
     loadSettings(): Promise<void>;
     saveSettings(): Promise<void>;

--- a/src/@types/map.d.ts
+++ b/src/@types/map.d.ts
@@ -65,6 +65,7 @@ declare class LeafletMap extends Events {
         /* type: "real" | "image",
          */ options?: {
             coords?: [number, number];
+            zoomDistance?: number;
             layers?: { data: string; id: string }[];
         }
     ): Promise<void>;

--- a/src/leaflet.ts
+++ b/src/leaflet.ts
@@ -247,6 +247,16 @@ class LeafletMap extends Events {
                 this.plugin.app.keymap.popScope(this._escapeScope);
             }
         });
+
+        this.map = L.map(this.contentEl, {
+            crs: this.CRS,
+            maxZoom: this.zoom.max,
+            minZoom: this.zoom.min,
+            zoomDelta: this.zoom.delta,
+            zoomSnap: this.zoom.delta,
+            worldCopyJump: this.type === "real",
+            fullscreenControl: true
+        });
     }
 
     get data() {
@@ -313,19 +323,10 @@ class LeafletMap extends Events {
     @catchErrorAsync
     async render(options: {
         coords: [number, number];
+        zoomDistance: number;
         layer: { data: string; id: string };
         hasAdditional?: boolean;
     }) {
-        this.map = L.map(this.contentEl, {
-            crs: this.CRS,
-            maxZoom: this.zoom.max,
-            minZoom: this.zoom.min,
-            zoomDelta: this.zoom.delta,
-            zoomSnap: this.zoom.delta,
-            worldCopyJump: this.type === "real",
-            fullscreenControl: true
-        });
-
         /** Get layers
          *  Returns TileLayer (real) or ImageOverlay (image)
          */
@@ -350,6 +351,16 @@ class LeafletMap extends Events {
             options.coords[1] * this._coordMult[1]
         ];
         this.map.panTo(this.initialCoords);
+        if (options.zoomDistance) {
+            const circle = L.circle(options.coords, {
+                radius: options.zoomDistance
+            });
+            circle.addTo(this.map);
+            this.map.setZoom(this.map.getBoundsZoom(circle.getBounds()), {
+                animate: false
+            });
+            circle.remove();
+        }
 
         /** Build Marker Layer Groups */
 

--- a/src/main.css
+++ b/src/main.css
@@ -241,11 +241,6 @@ input.is-invalid {
     cursor: pointer !important;
 }
 
-.use-csv-marker > svg {
-    color: yellow;
-    margin-right: 8px;
-}
-
 .leaflet-file-upload > input[type="file"] {
     display: none;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -442,9 +442,7 @@ export class ObsidianLeafletSettingTab extends PluginSettingTab {
         const importSetting = new Setting(containerEl).setDesc(
             "This setting is experimental and could cause marker data issues. Use at your own risk."
         );
-        let name = importSetting.nameEl.createDiv({
-            cls: "use-csv-marker"
-        });
+        let name = importSetting.nameEl.createDiv();
         name.appendChild(
             icon(
                 findIconDefinition({

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,7 @@
 import { ILeafletMapOptions, IObsidianAppData } from "src/@types";
 
+export const OVERLAY_TAG_REGEX = /^(\d+(?:\.\d+)?)\s?(\w*)/;
+
 export const LAT_LONG_DECIMALS = 4;
 export const DISTANCE_DECIMALS = 1;
 export const DEFAULT_MAP_OPTIONS: ILeafletMapOptions = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -13,10 +13,11 @@ import { getType as lookupMimeType } from "mime/lite";
 import { parse as parseCSV } from "papaparse";
 
 import { IBlockParameters } from "src/@types";
+import { OVERLAY_TAG_REGEX } from "./constants";
+import { latLng, LatLng, LatLngTuple } from "leaflet";
 
 export function renderError(el: HTMLElement, error: string): void {
-    
-    let pre =createEl("pre", { attr: { id: "leaflet-error" } });
+    let pre = createEl("pre", { attr: { id: "leaflet-error" } });
     pre.setText(`\`\`\`leaflet
 There was an error rendering the map:
 
@@ -422,9 +423,8 @@ export async function getImmutableItems(
                         overlayTag
                     )
                 ) {
-                    const match = frontmatter[overlayTag].match(
-                        /^(\d+(?:\.\d+)?)\s?(\w*)/
-                    );
+                    const match =
+                        frontmatter[overlayTag].match(OVERLAY_TAG_REGEX);
                     if (!match) {
                         new Notice(
                             `Could not parse ${overlayTag} in ${file.name}. Please ensure it is in the format: <distance> <unit>`


### PR DESCRIPTION
- Add new `coordinates` and `zoomTag` parameter
    - `coordinates` can be used in lieu of `lat` and `long` parameters
    - If the `coordinates` is a note file wikilink, it will read the note file's `location` frontmatter tag and use that for initial starting coordinates
    - If `zoomTag` is specified, it will read the tag from the frontmatter of the _same_ file specified in `coordinates`. If `coordinates` is not a file, `zoomTag` does nothing.
          - It will use the tag (formatted the same as `overlayTag` - `<distance> <unit>`) to calculate the default zoom level to display