### PR TITLE
Add support for .gpx.gz file parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,8 @@
                 "webpack-cli": "^4.7.2",
                 "webpack-inject-plugin": "^1.5.5",
                 "worker-loader": "^3.0.8",
-                "xmldom": "^0.6.0"
+                "xmldom": "^0.6.0",
+                "zlib": "^1.0.5"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -4518,6 +4519,16 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/zlib": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+            "integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "engines": {
+                "node": ">=0.2.0"
+            }
         }
     },
     "dependencies": {
@@ -7917,6 +7928,12 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true
+        },
+        "zlib": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+            "integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "webpack-cli": "^4.7.2",
         "webpack-inject-plugin": "^1.5.5",
         "worker-loader": "^3.0.8",
-        "xmldom": "^0.6.0"
+        "xmldom": "^0.6.0",
+        "zlib": "^1.0.5"
     }
 }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -536,7 +536,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
                     gpxSet.add({ path });
                 if (abstractFile instanceof TFolder) {
                     Vault.recurseChildren(abstractFile, (file) => {
-                        if (file instanceof TFile && file.extension === "gpx")
+                        if (file instanceof TFile && (file.extension === "gpx" || file.path.endsWith(".gpx.gz")))
                             gpxSet.add({ path: file.path });
                     });
                 }
@@ -550,8 +550,13 @@ export class LeafletRenderer extends MarkdownRenderChild {
                     this.sourcePath
                 );
                 if (file && file instanceof TFile) {
-                    let data = await this.plugin.app.vault.read(file);
-                    if (file.extension === 'gz') data = (await doUnzip(data)).toString();
+                    let data: string;
+                    if(file.extension === 'gz') {
+                        let dataBuffer = await this.plugin.app.vault.readBinary(file);
+                        data = (await doUnzip(dataBuffer)).toString();
+                    } else {
+                        data = await this.plugin.app.vault.read(file);
+                    }
                     gpxData.push({ data, alias });
                 }
             }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,3 +1,4 @@
+import { unzip } from "zlib";
 import {
     MarkdownRenderChild,
     TFile,
@@ -38,6 +39,8 @@ import convert from "convert";
 import t from "../l10n/locale";
 import { LeafletMapView } from "src/map/view";
 import { Marker, Overlay } from "src/layer";
+import { promisify } from "util";
+const doUnzip = promisify(unzip);
 
 declare module "leaflet" {
     interface Map {
@@ -548,6 +551,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
                 );
                 if (file && file instanceof TFile) {
                     let data = await this.plugin.app.vault.read(file);
+                    if (file.extension === 'gz') data = (await doUnzip(data)).toString();
                     gpxData.push({ data, alias });
                 }
             }


### PR DESCRIPTION
This adds support for including .gpx.gz files.

I'm using this to include activities from Strava, which (at least in my case) default to being gzipped.  The compression from gzip is pretty significant, and I wanted to avoid having to include the activities in uncompressed form.

Because the files have a `.gpx.gz` extension I had to check for that in the `file.path` attribute, rather than using `file.extension`.
