### PR TITLE
Switch to using pako from node's zlib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,12 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "obsidian-leaflet-plugin",
             "version": "5.0.4",
             "license": "MIT",
+            "dependencies": {
+                "pako": "^2.1.0"
+            },
             "devDependencies": {
                 "@fortawesome/fontawesome-svg-core": "^1.2.35",
                 "@fortawesome/free-regular-svg-icons": "^5.15.2",
@@ -18,6 +22,7 @@
                 "@types/leaflet-fullscreen": "^1.0.4",
                 "@types/mime": "^2.0.3",
                 "@types/node": "^14.14.31",
+                "@types/pako": "^2.0.0",
                 "@types/papaparse": "^5.2.5",
                 "@types/xmldom": "^0.1.31",
                 "color": "^3.1.3",
@@ -403,6 +408,12 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
             "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+            "dev": true
+        },
+        "node_modules/@types/pako": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.0.tgz",
+            "integrity": "sha512-10+iaz93qR5WYxTo+PMifD5TSxiOtdRaxBf7INGGXMQgTCu8Z/7GYWYFUOS3q/G0nE5boj1r4FEB+WSy7s5gbA==",
             "dev": true
         },
         "node_modules/@types/papaparse": {
@@ -2965,6 +2976,11 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+        },
         "node_modules/papaparse": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
@@ -4832,6 +4848,12 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
             "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+            "dev": true
+        },
+        "@types/pako": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.0.tgz",
+            "integrity": "sha512-10+iaz93qR5WYxTo+PMifD5TSxiOtdRaxBf7INGGXMQgTCu8Z/7GYWYFUOS3q/G0nE5boj1r4FEB+WSy7s5gbA==",
             "dev": true
         },
         "@types/papaparse": {
@@ -6823,6 +6845,11 @@
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
+        },
+        "pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         },
         "papaparse": {
             "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@types/leaflet-fullscreen": "^1.0.4",
         "@types/mime": "^2.0.3",
         "@types/node": "^14.14.31",
+        "@types/pako": "^2.0.0",
         "@types/papaparse": "^5.2.5",
         "@types/xmldom": "^0.1.31",
         "color": "^3.1.3",
@@ -54,7 +55,9 @@
         "webpack-cli": "^4.7.2",
         "webpack-inject-plugin": "^1.5.5",
         "worker-loader": "^3.0.8",
-        "xmldom": "^0.6.0",
-        "zlib": "^1.0.5"
+        "xmldom": "^0.6.0"
+    },
+    "dependencies": {
+        "pako": "^2.1.0"
     }
 }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,4 +1,4 @@
-import { unzip } from "zlib";
+import { ungzip } from "pako";
 import {
     MarkdownRenderChild,
     TFile,
@@ -40,7 +40,6 @@ import t from "../l10n/locale";
 import { LeafletMapView } from "src/map/view";
 import { Marker, Overlay } from "src/layer";
 import { promisify } from "util";
-const doUnzip = promisify(unzip);
 
 declare module "leaflet" {
     interface Map {
@@ -553,7 +552,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
                     let data: string;
                     if(file.extension === 'gz') {
                         let dataBuffer = await this.plugin.app.vault.readBinary(file);
-                        data = (await doUnzip(dataBuffer)).toString();
+                        data = ungzip(dataBuffer, {to: 'string'});
                     } else {
                         data = await this.plugin.app.vault.read(file);
                     }


### PR DESCRIPTION
In #319, zlib was used to decompress gpx.gz files.  This switches to using pako, which is a pure-JS library that doesn't rely on Node's zlib linkings.

The two things I was not certain about:

 - I added the dependency to the dependencies list in package.json.  Does it need to be anywhere else?
 - I've changed to using non-promisify'd `ungzip`, as the output values were not being correctly passed through the promisification when I used the options.  (I was ending with `Promise<unknown>` as the return value).  Any suggestions there would be helpful!

This should close #325.
