### PR TITLE
Implement saving the current drawings as a GeoJSON file for Issue #337

### DIFF
--- a/src/draw/controls.ts
+++ b/src/draw/controls.ts
@@ -8,6 +8,7 @@ import t from "src/l10n/locale";
 import { LeafletSymbol } from "src/utils/leaflet-import";
 import { BaseDrawControl } from "./base";
 import { ColorControl } from "./color";
+import { GeoJSONControl } from "./geojson";
 import { PolygonControl } from "./polygon";
 import { PolylineControl } from "./polyline";
 import { RectangleControl } from "./rectangle";
@@ -28,6 +29,7 @@ export class DrawControl extends FontAwesomeControl {
     color = new ColorControl(this);
     drag = new DragControl(this);
     delete = new DeleteControl(this);
+    geoJson = new GeoJSONControl(this);
     done = new DoneControl(this);
 
     /* free: FreeControl; */
@@ -87,6 +89,7 @@ export class DrawControl extends FontAwesomeControl {
         this.section.appendChild(this.drag.controlEl);
 
         this.section.appendChild(this.delete.controlEl);
+        this.section.appendChild(this.geoJson.controlEl);
         this.section.appendChild(this.done.controlEl);
     }
     private expand() {

--- a/src/draw/geojson.ts
+++ b/src/draw/geojson.ts
@@ -1,0 +1,42 @@
+import t from "src/l10n/locale";
+import { BaseMapType } from "src/@types";
+import { DrawControl } from "./controls";
+import { FontAwesomeControl, FontAwesomeControlOptions } from "src/controls/controls";
+import { LayerGroup, Polyline } from "leaflet";
+import { GeoJSONModal } from "src/modals/geojson";
+
+export class GeoJSONControl extends FontAwesomeControl {
+    get map() {
+        return this.parent.map;
+    }
+    constructor(private parent: DrawControl) {
+        super(
+            {
+                icon: "save",
+                cls: "leaflet-control-has-actions leaflet-control-save",
+                tooltip: t("Export Drawing to GeoJSON")
+            },
+            parent.map.leafletInstance
+        );
+    }
+    onClick(evt: MouseEvent) {
+        evt.stopPropagation();
+
+        const { plugin } = this.map;
+        
+        const features: Array<Polyline> = [];
+        
+        this.map.controller.flatShapes.forEach(shape => {
+            if (shape.leafletInstance instanceof Polyline) {
+                features.push(shape.leafletInstance);
+            }
+        });
+
+        const result = JSON.stringify(features.map(feature => feature.toGeoJSON()));
+        const newFilePath = plugin.app.fileManager.getNewFileParent(plugin.app.workspace.getActiveFile().path);
+
+        new GeoJSONModal(plugin.app, (fileName) => {
+            plugin.app.vault.adapter.write(`${newFilePath.path}/${fileName}.json`, result);
+        }).open();
+    }
+}

--- a/src/l10n/locales/en.ts
+++ b/src/l10n/locales/en.ts
@@ -205,6 +205,10 @@ export default {
     "Overlay Color": "Overlay Color",
     "Delete Overlay": "Delete Overlay",
 
+    //modals/geojson.ts
+    "File Name": "File Name",
+    "Enter a file name.": "Enter a file name.",
+
     //map/view.ts
     "Leaflet Map": "Leaflet Map",
 
@@ -280,5 +284,6 @@ export default {
     Text: "Text",
     Color: "Color",
     "Fill Color": "Fill Color",
-    "Move Shapes": "Move Shapes"
+    "Move Shapes": "Move Shapes",
+    "Export Drawing to GeoJSON": "Export Drawing to GeoJSON",
 };

--- a/src/modals/geojson.ts
+++ b/src/modals/geojson.ts
@@ -1,0 +1,40 @@
+import { App, Modal, Setting } from "obsidian";
+import t from "src/l10n/locale";
+
+export class GeoJSONModal extends Modal {
+  result: string;
+
+  onSubmit: (result: string) => void;
+
+  constructor(app: App, onSubmit: (result: string) => void) {
+    super(app);
+    this.onSubmit = onSubmit;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+
+    contentEl.createEl("h1", { text: t("Enter a file name.") });
+
+    new Setting(contentEl)
+      .setName(t("File Name"))
+      .addText((text) => {
+        text.onChange(value => this.result = value);
+      });
+
+    new Setting(contentEl)
+      .addButton(button => {
+        button.setButtonText(t("Save"))
+          .setCta()
+          .onClick(() => {
+            this.close();
+            this.onSubmit(this.result);
+          });
+      });
+  }
+
+  onClose() {
+    let { contentEl } = this;
+    contentEl.empty();
+  }
+}


### PR DESCRIPTION
This simple change adds a button at the bottom of the drawings panel, that will grab all of the currently active drawings and export them into a .json file in GeoJSON format, as requested in issue #337