### PR TITLE
FIX: gpxFolder incorrect gpx collection

### DIFF
--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -589,7 +589,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
                             (file.extension === "gpx" ||
                                 file.path.endsWith(".gpx.gz"))
                         )
-                            gpxSet.set(path, { path: file.path });
+                            gpxSet.set(file.path, { path: file.path });
                     });
                 }
             }


### PR DESCRIPTION
Bug fix: After 'gpxSet' was changed from Set to Map only the last file in the folder will be added to the Map.